### PR TITLE
Fix journey transformation throwing exception

### DIFF
--- a/lib/journeys.js
+++ b/lib/journeys.js
@@ -69,20 +69,20 @@ const transformFare = (f) => ({
 	currency: 'EUR'
 })
 
-const transformTariffs = (t) => ({
+const transformTariffs = (t) => (t && {
 	model: t.tickets['1t0'].name,
 	amount: +(t.tickets['1t0'].price) / 100,
 	currency: 'EUR',
 	fares: toArray(t.tickets).map(transformFare)
 })
 
-const transformZones = (z) => ({
+const transformZones = (z) => (z && {
 	departure: z.zone_start,
 	arrival: z.zone_end,
 	list: z.zones // todo
 })
 
-const transformJourney = (j) => ({
+const transformJourney = (j) => (j && {
 	type: 'journey',
 	id: hashJourney(j),
 	legs: j.sections.map(transformLeg),


### PR DESCRIPTION
This PR should fix the issue #17. 

There are no `prices` and `zones` to be transformed if the API returns a walking only route.

Instead of throwing an exception, these values will be `null` after this change.